### PR TITLE
Multithreading in forward!

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This is a port of Andrew Karpathy's [llama2.c](https://github.com/karpathy/llama
 - Inference, generation loop and chat loop
 - argmax, multinomial and top-p sampling
 - Tokenizer for encoding text to LLM input and decoding LLM output to text
+- Multi-threading in transformer forward function ([#37](https://github.com/kleincode/Llama2.jl/pull/37))
+- Compatibility tested with all of [Andrew Karpathy's models](https://github.com/karpathy/llama2.c/tree/master?tab=readme-ov-file#models)
 
 ## Getting started
 Add the package to your local environment via Pkg by running

--- a/src/transformer.jl
+++ b/src/transformer.jl
@@ -1,4 +1,5 @@
 using LinearAlgebra
+using Base.Threads
 
 """
 $(TYPEDEF)
@@ -214,7 +215,7 @@ julia> forward!(transformer, 5, 1)
         mul!(s.value_cache[:, pos, l], w.wv[:, :, l]', s.xb) # (kv_dim,) = (kv_dim, dim) * (n_heads * head_size,)
 
         # RoPE relative positional encoding: complex-valued rotate q and k in each head
-        for i in 1:2:dim
+        Threads.@threads for i in 1:2:dim
             head_dim = (i - 1) % head_size
             freq = 1.0f0 / (10000.0f0^(head_dim / head_size))
             val = (pos - 1) * freq


### PR DESCRIPTION
Enable multithreading using the `Threads.@threads` macro.
- enabling this on the RoPE loop decreases runtime by about 25%
- enabling this on the head loop does not decrease runtime, sometimes even icreases runtime slightly -> won't do

## Benchmarking code
```julia
using Llama2
using BenchmarkTools

config, weights = read_karpathy("bin/transformer/stories15M.bin") # or stories110M.bin
state = RunState{Float32}(config)
transformer = Transformer{Float32}(config, weights, state)

@benchmark forward!(transformer, 1, 1)
```

## Before multithreading
### stories15M.bin
```
BenchmarkTools.Trial: 1937 samples with 1 evaluation.
 Range (min … max):  2.361 ms …   5.889 ms  ┊ GC (min … max): 0.00% … 56.06%
 Time  (median):     2.499 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.571 ms ± 291.406 μs  ┊ GC (mean ± σ):  0.56% ±  3.66%

   ▂█▇▇▁▁▁▃▁
  ▄██████████▆▆▆▅▄▅▄▃▃▄▃▂▃▂▂▂▂▂▂▂▂▂▂▁▂▁▂▂▁▁▂▂▃▃▂▂▂▃▂▃▂▁▂▂▂▂▂▂ ▃
  2.36 ms         Histogram: frequency by time        3.54 ms <

 Memory estimate: 495.98 KiB, allocs estimate: 24489.
```

### stories110M.bin
```
BenchmarkTools.Trial: 340 samples with 1 evaluation.
 Range (min … max):  13.248 ms … 32.860 ms  ┊ GC (min … max): 0.00% … 57.67%
 Time  (median):     14.523 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   14.715 ms ±  1.498 ms  ┊ GC (mean ± σ):  0.75% ±  4.36%

                 ▁ ▆█▇▃▁▆▅▄  
  ▃▁▁▁▁▁▁▄▄▇▄█▅▃▄█▆█████████▇▆▅▅▆▇▅▅▄▄▄▅▄▃▃▃▄▄▃▃▃▃▁▃▁▃▁▁▁▃▁▃▃ ▄
  13.2 ms         Histogram: frequency by time        16.6 ms <

 Memory estimate: 2.73 MiB, allocs estimate: 143130.
```

## With multithreading
### stories15M.bin
```
BenchmarkTools.Trial: 2540 samples with 1 evaluation.
 Range (min … max):  1.801 ms …   5.931 ms  ┊ GC (min … max): 0.00% … 63.55%
 Time  (median):     1.890 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.958 ms ± 228.916 μs  ┊ GC (mean ± σ):  0.21% ±  2.14%

   ▅█▅▅▁
  ▅█████▇▆▅▅▄▄▄▄▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▃▃▂▂▂▂▂▂▂▂▂▂▂▂▁▂▁▁▁▂▁▂ ▃
  1.8 ms          Histogram: frequency by time        2.95 ms <

 Memory estimate: 95.95 KiB, allocs estimate: 1209.
```

### stories110M.bin
```
BenchmarkTools.Trial: 458 samples with 1 evaluation.
 Range (min … max):  10.318 ms …  12.303 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     10.780 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.912 ms ± 364.027 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

            ▅█▇▁▅
  ▃▁▁▄▃▃▅▅███████▆█▅▇▃▅▅▇▅▅▆▅▅▃▅▅▅▅▅▃▅▆▃▃▁▃▃▃▃▃▃▃▂▃▂▁▃▃▃▂▂▃▂▂▂ ▃
  10.3 ms         Histogram: frequency by time           12 ms <

 Memory estimate: 425.28 KiB, allocs estimate: 4926.
```